### PR TITLE
Added total time from buzzer to last shot, fixed min time for first shot, fixed lag between internal and external buzzer, added beep to timer delay setting and beep frequency sweep.

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -9,7 +9,7 @@ BC          ?= bc
 
 PARTITION_TABLE=~/.arduino15/packages/m5stack/hardware/esp32/2.1.4/tools/partitions/default_8MB.csv
 
-DEVICE :=/dev/ttyACM0
+DEVICE :=/dev/cu.usbserial-5B212384801
 
 .PHONY: build
 build:

--- a/code/audio_utils.cpp
+++ b/code/audio_utils.cpp
@@ -5,19 +5,26 @@
 #include <freertos/task.h>     
 #include <freertos/queue.h>
 
+// --- LEDC Configuration for Buzzers ---
+#define BUZZER_LEDC_CHANNEL 2
+#define BUZZER_LEDC_RESOLUTION 8
+
 // --- Buzzer Task (Runs on Core 0) ---
 void buzzerTask(void *pvParameters) {
     BuzzerRequest receivedRequest;
-    TickType_t lastWakeTime = xTaskGetTickCount(); 
+
+    // Attach both buzzer pins to the same LEDC channel/timer
+    // so they fire in perfect hardware sync
+    ledcSetup(BUZZER_LEDC_CHANNEL, 2000, BUZZER_LEDC_RESOLUTION);
+    ledcAttachPin(BUZZER_PIN, BUZZER_LEDC_CHANNEL);
+    ledcAttachPin(BUZZER_PIN_2, BUZZER_LEDC_CHANNEL);
 
     for (;;) {
         if (xQueueReceive(buzzerQueue, &receivedRequest, portMAX_DELAY) == pdPASS) {
             if (receivedRequest.frequency > 0 && receivedRequest.duration > 0) {
-                tone(BUZZER_PIN, receivedRequest.frequency, receivedRequest.duration);
-                tone(BUZZER_PIN_2, receivedRequest.frequency, receivedRequest.duration);
-                vTaskDelay(pdMS_TO_TICKS(receivedRequest.duration + 5)); 
-                noTone(BUZZER_PIN);
-                noTone(BUZZER_PIN_2);
+                ledcWriteTone(BUZZER_LEDC_CHANNEL, receivedRequest.frequency);
+                vTaskDelay(pdMS_TO_TICKS(receivedRequest.duration));
+                ledcWriteTone(BUZZER_LEDC_CHANNEL, 0);
             } else if (receivedRequest.duration > 0) {
                  vTaskDelay(pdMS_TO_TICKS(receivedRequest.duration));
             }

--- a/code/code.ino
+++ b/code/code.ino
@@ -46,6 +46,8 @@ float recoilThreshold = 1.5f;
 int screenRotationSetting = 3;
 bool playBootAnimation = true;
 bool enableAutoSleep = true;
+bool showTotalTime = false;
+int minFirstShotTimeMs = 100;
 
 BluetoothA2DPSource a2dp_source;
 String currentBluetoothDeviceName = "LEXON MINO L";

--- a/code/code.ino
+++ b/code/code.ino
@@ -48,6 +48,7 @@ bool playBootAnimation = true;
 bool enableAutoSleep = true;
 bool showTotalTime = false;
 int minFirstShotTimeMs = 100;
+int postBeepDelayMs = 200;
 
 BluetoothA2DPSource a2dp_source;
 String currentBluetoothDeviceName = "LEXON MINO L";

--- a/code/code.ino
+++ b/code/code.ino
@@ -86,6 +86,7 @@ unsigned long lastDetectionTime = 0;
 
 int currentMenuSelection = 0;
 int menuScrollOffset = 0;
+int shotReviewIndex = -1;
 int settingsMenuLevel = 0;
 unsigned long btnTopPressTime = 0;
 bool btnTopHeld = false;
@@ -380,21 +381,56 @@ void loop() {
         case LIVE_FIRE_GET_READY:     handleLiveFireGetReady(); break;
         case LIVE_FIRE_TIMING:        handleLiveFireTiming(); break;
         case LIVE_FIRE_STOPPED:
-            if (redrawMenu) {
-                displayStoppedScreen();
-                redrawMenu = false;
-            }
-            if (StickCP2.BtnA.wasClicked()) {
-                resetActivityTimer();
-                if (previousState == NOISY_RANGE_TIMING || previousState == NOISY_RANGE_GET_READY || currentMode == MODE_NOISY_RANGE) {
-                     setState(NOISY_RANGE_READY);
-                } else if (previousState == DRY_FIRE_RUNNING || currentMode == MODE_DRY_FIRE) { 
-                    setState(DRY_FIRE_READY); 
+            {
+                if (redrawMenu) {
+                    if (shotReviewIndex < 0) {
+                        displayStoppedScreen();
+                    } else {
+                        displayShotReviewScreen(shotReviewIndex);
+                    }
+                    redrawMenu = false;
                 }
-                else { 
-                    setState(LIVE_FIRE_READY);
+
+                int rotation = StickCP2.Lcd.getRotation();
+                bool upPressed = (rotation == 3) ? M5.BtnPWR.wasClicked() : StickCP2.BtnB.wasClicked();
+                bool downPressed = (rotation == 3) ? StickCP2.BtnB.wasClicked() : M5.BtnPWR.wasClicked();
+
+                if (shotCount > 0) {
+                    if (downPressed) {
+                        resetActivityTimer();
+                        if (shotReviewIndex < shotCount - 1) {
+                            shotReviewIndex++;
+                        }
+                        StickCP2.Lcd.fillScreen(BLACK);
+                        displayShotReviewScreen(shotReviewIndex);
+                    }
+                    if (upPressed) {
+                        resetActivityTimer();
+                        if (shotReviewIndex > 0) {
+                            shotReviewIndex--;
+                            StickCP2.Lcd.fillScreen(BLACK);
+                            displayShotReviewScreen(shotReviewIndex);
+                        } else if (shotReviewIndex == 0) {
+                            shotReviewIndex = -1;
+                            StickCP2.Lcd.fillScreen(BLACK);
+                            displayStoppedScreen();
+                        }
+                    }
                 }
-                StickCP2.Lcd.fillScreen(BLACK);
+
+                if (StickCP2.BtnA.wasClicked()) {
+                    resetActivityTimer();
+                    shotReviewIndex = -1;
+                    if (previousState == NOISY_RANGE_TIMING || previousState == NOISY_RANGE_GET_READY || currentMode == MODE_NOISY_RANGE) {
+                         setState(NOISY_RANGE_READY);
+                    } else if (previousState == DRY_FIRE_RUNNING || currentMode == MODE_DRY_FIRE) { 
+                        setState(DRY_FIRE_READY); 
+                    }
+                    else { 
+                        setState(LIVE_FIRE_READY);
+                    }
+                    StickCP2.Lcd.fillScreen(BLACK);
+                }
             }
             break;
         case DRY_FIRE_READY:          handleDryFireReadyInput(); break;

--- a/code/config.cpp
+++ b/code/config.cpp
@@ -16,3 +16,5 @@ const char* KEY_BT_DEVICE_NAME = "btDevName";
 const char* KEY_BT_AUTO_RECONNECT = "btAutoRec";
 const char* KEY_BT_VOLUME = "btVolume";
 const char* KEY_BT_AUDIO_OFFSET = "btAudioOffset"; // New NVS Key Definition
+const char* KEY_SHOW_TOTAL_TIME = "showTotTime";
+const char* KEY_MIN_FIRST_SHOT = "minFirstShot";

--- a/code/config.cpp
+++ b/code/config.cpp
@@ -18,3 +18,4 @@ const char* KEY_BT_VOLUME = "btVolume";
 const char* KEY_BT_AUDIO_OFFSET = "btAudioOffset"; // New NVS Key Definition
 const char* KEY_SHOW_TOTAL_TIME = "showTotTime";
 const char* KEY_MIN_FIRST_SHOT = "minFirstShot";
+const char* KEY_POST_BEEP_DELAY = "postBeepDly";

--- a/code/config.h
+++ b/code/config.h
@@ -16,7 +16,7 @@ const int MENU_ITEM_HEIGHT_LANDSCAPE = 25;
 const int MENU_ITEM_HEIGHT_PORTRAIT = 18;
 const int MENU_ITEMS_PER_SCREEN_LANDSCAPE = 3;
 const int MENU_ITEMS_PER_SCREEN_PORTRAIT = 5;
-const unsigned long POST_BEEP_DELAY_MS = 750; // Increased further to 750ms
+const unsigned long DEFAULT_POST_BEEP_DELAY_MS = 200; // Default post-beep delay before timing starts
 const int MAX_FILES_LIST = 20;
 const unsigned long BOOT_JPG_FRAME_DELAY_MS = 100;
 const int MAX_BOOT_JPG_FRAMES = 150;
@@ -58,6 +58,7 @@ extern const char* KEY_BT_VOLUME;
 extern const char* KEY_BT_AUDIO_OFFSET; 
 extern const char* KEY_SHOW_TOTAL_TIME;
 extern const char* KEY_MIN_FIRST_SHOT;
+extern const char* KEY_POST_BEEP_DELAY;
 
 // --- Timer States ---
 enum TimerState {
@@ -111,7 +112,8 @@ enum EditableSetting {
     EDIT_BT_VOLUME,
     EDIT_BT_AUDIO_OFFSET,
     EDIT_SHOW_TOTAL_TIME,
-    EDIT_MIN_FIRST_SHOT 
+    EDIT_MIN_FIRST_SHOT,
+    EDIT_POST_BEEP_DELAY 
 };
 
 // --- Struct for Buzzer Task Queue ---

--- a/code/config.h
+++ b/code/config.h
@@ -113,7 +113,8 @@ enum EditableSetting {
     EDIT_BT_AUDIO_OFFSET,
     EDIT_SHOW_TOTAL_TIME,
     EDIT_MIN_FIRST_SHOT,
-    EDIT_POST_BEEP_DELAY 
+    EDIT_POST_BEEP_DELAY,
+    EDIT_TONE_SWEEP 
 };
 
 // --- Struct for Buzzer Task Queue ---

--- a/code/config.h
+++ b/code/config.h
@@ -25,7 +25,7 @@ const unsigned long DRY_FIRE_RANDOM_DELAY_MIN_MS = 2000;
 const unsigned long DRY_FIRE_RANDOM_DELAY_MAX_MS = 5000;
 const int MAX_PAR_BEEPS = 10;
 const unsigned long RECOIL_DETECTION_WINDOW_MS = 100;
-const unsigned long MIN_FIRST_SHOT_TIME_MS = 100; // Min time after start for first shot
+const unsigned long DEFAULT_MIN_FIRST_SHOT_TIME_MS = 100; // Default min time after start for first shot
 const unsigned long AUTO_SLEEP_TIMEOUT_MS = 1 * 60 * 1000;
 const unsigned long SLEEP_MESSAGE_DELAY_MS = 1500;
 // #define C3_FREQUENCY 130.81f // No longer used for keep-alive
@@ -56,6 +56,8 @@ extern const char* KEY_BT_DEVICE_NAME;
 extern const char* KEY_BT_AUTO_RECONNECT;
 extern const char* KEY_BT_VOLUME;
 extern const char* KEY_BT_AUDIO_OFFSET; 
+extern const char* KEY_SHOW_TOTAL_TIME;
+extern const char* KEY_MIN_FIRST_SHOT;
 
 // --- Timer States ---
 enum TimerState {
@@ -107,7 +109,9 @@ enum EditableSetting {
     EDIT_AUTO_SLEEP,
     EDIT_BT_AUTO_RECONNECT,
     EDIT_BT_VOLUME,
-    EDIT_BT_AUDIO_OFFSET 
+    EDIT_BT_AUDIO_OFFSET,
+    EDIT_SHOW_TOTAL_TIME,
+    EDIT_MIN_FIRST_SHOT 
 };
 
 // --- Struct for Buzzer Task Queue ---

--- a/code/display_utils.cpp
+++ b/code/display_utils.cpp
@@ -118,6 +118,7 @@ void displayMenu(const char* title, const char* items[], int count, int selectio
             else if (strcmp(items[i], "Auto Sleep") == 0) itemText += (enableAutoSleep ? "On" : "Off");
             else if (strcmp(items[i], "Show Total Time") == 0) itemText += (showTotalTime ? "On" : "Off");
             else if (strcmp(items[i], "Min 1st Shot") == 0) { itemText += minFirstShotTimeMs; itemText += "ms"; }
+            else if (strcmp(items[i], "Post Beep Delay") == 0) { itemText += postBeepDelayMs; itemText += "ms"; }
             else if (settingsMenuLevel == 5 && strcmp(items[i], "Auto Reconnect") == 0) {
                 itemText += (currentBluetoothAutoReconnect ? "On" : "Off");
             }
@@ -318,9 +319,10 @@ void displayEditScreen() {
         case EDIT_BT_VOLUME:
         case EDIT_BT_AUDIO_OFFSET: 
         case EDIT_MIN_FIRST_SHOT:
+        case EDIT_POST_BEEP_DELAY:
              StickCP2.Lcd.setTextFont(7); StickCP2.Lcd.setTextSize(1);
              StickCP2.Lcd.drawNumber(editingIntValue, StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() / 2);
-             if (settingBeingEdited == EDIT_BT_AUDIO_OFFSET || settingBeingEdited == EDIT_MIN_FIRST_SHOT) { 
+             if (settingBeingEdited == EDIT_BT_AUDIO_OFFSET || settingBeingEdited == EDIT_MIN_FIRST_SHOT || settingBeingEdited == EDIT_POST_BEEP_DELAY) { 
                 StickCP2.Lcd.setTextFont(0); StickCP2.Lcd.setTextSize(1); 
                 StickCP2.Lcd.drawString("ms", StickCP2.Lcd.width() / 2 + StickCP2.Lcd.textWidth(String(editingIntValue))/2 + 15, StickCP2.Lcd.height() / 2);
              }

--- a/code/display_utils.cpp
+++ b/code/display_utils.cpp
@@ -98,7 +98,8 @@ void displayMenu(const char* title, const char* items[], int count, int selectio
                               strcmp(items[i], "List Files") == 0 ||
                               strcmp(items[i], "Power Off Now") == 0 ||
                               strcmp(items[i], "Beep Settings") == 0 ||
-                              strcmp(items[i], "Bluetooth Settings") == 0);
+                              strcmp(items[i], "Bluetooth Settings") == 0 ||
+                              strcmp(items[i], "Tone Sweep") == 0);
 
         bool isParTimeSetting = (settingsMenuLevel == 2 && strncmp(items[i], "Par Time", 8) == 0);
         bool isBluetoothConnectItem = (settingsMenuLevel == 5 && strcmp(items[i], "Connect") == 0 );
@@ -320,11 +321,16 @@ void displayEditScreen() {
         case EDIT_BT_AUDIO_OFFSET: 
         case EDIT_MIN_FIRST_SHOT:
         case EDIT_POST_BEEP_DELAY:
+        case EDIT_TONE_SWEEP:
              StickCP2.Lcd.setTextFont(7); StickCP2.Lcd.setTextSize(1);
              StickCP2.Lcd.drawNumber(editingIntValue, StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() / 2);
              if (settingBeingEdited == EDIT_BT_AUDIO_OFFSET || settingBeingEdited == EDIT_MIN_FIRST_SHOT || settingBeingEdited == EDIT_POST_BEEP_DELAY) { 
                 StickCP2.Lcd.setTextFont(0); StickCP2.Lcd.setTextSize(1); 
                 StickCP2.Lcd.drawString("ms", StickCP2.Lcd.width() / 2 + StickCP2.Lcd.textWidth(String(editingIntValue))/2 + 15, StickCP2.Lcd.height() / 2);
+             }
+             if (settingBeingEdited == EDIT_TONE_SWEEP) { 
+                StickCP2.Lcd.setTextFont(0); StickCP2.Lcd.setTextSize(1); 
+                StickCP2.Lcd.drawString("Hz", StickCP2.Lcd.width() / 2 + StickCP2.Lcd.textWidth(String(editingIntValue))/2 + 15, StickCP2.Lcd.height() / 2);
              }
              break;
         case EDIT_BEEP_DURATION:

--- a/code/display_utils.cpp
+++ b/code/display_utils.cpp
@@ -116,6 +116,8 @@ void displayMenu(const char* title, const char* items[], int count, int selectio
             else if (strcmp(items[i], "Screen Rotation") == 0) itemText += screenRotationSetting;
             else if (strcmp(items[i], "Boot Animation") == 0) itemText += (playBootAnimation ? "On" : "Off");
             else if (strcmp(items[i], "Auto Sleep") == 0) itemText += (enableAutoSleep ? "On" : "Off");
+            else if (strcmp(items[i], "Show Total Time") == 0) itemText += (showTotalTime ? "On" : "Off");
+            else if (strcmp(items[i], "Min 1st Shot") == 0) { itemText += minFirstShotTimeMs; itemText += "ms"; }
             else if (settingsMenuLevel == 5 && strcmp(items[i], "Auto Reconnect") == 0) {
                 itemText += (currentBluetoothAutoReconnect ? "On" : "Off");
             }
@@ -229,9 +231,17 @@ void displayStoppedScreen() {
 
     StickCP2.Lcd.setTextSize(text_size);
 
-    StickCP2.Lcd.setCursor(10, y_pos);
-    StickCP2.Lcd.printf("Total Shots: %d", shotCount);
-    y_pos += line_h;
+    if (showTotalTime && shotCount > 0) {
+        // Show total elapsed time (buzzer to last shot) with shot count
+        float totalTime = (shotTimestamps[shotCount - 1] - startTime) / 1000.0f;
+        StickCP2.Lcd.setCursor(10, y_pos);
+        StickCP2.Lcd.printf("Total: %.2fs (%d)", totalTime, shotCount);
+        y_pos += line_h;
+    } else {
+        StickCP2.Lcd.setCursor(10, y_pos);
+        StickCP2.Lcd.printf("Total Shots: %d", shotCount);
+        y_pos += line_h;
+    }
 
     StickCP2.Lcd.setCursor(10, y_pos);
     if (shotCount > 0) { StickCP2.Lcd.printf("First: %.2fs", splitTimes[0]); }
@@ -289,7 +299,7 @@ void displayEditScreen() {
         StickCP2.Lcd.setTextDatum(BC_DATUM);
         StickCP2.Lcd.setTextFont(0);
         StickCP2.Lcd.setTextSize(1);
-        if (settingBeingEdited == EDIT_BOOT_ANIM || settingBeingEdited == EDIT_AUTO_SLEEP || settingBeingEdited == EDIT_BT_AUTO_RECONNECT) {
+        if (settingBeingEdited == EDIT_BOOT_ANIM || settingBeingEdited == EDIT_AUTO_SLEEP || settingBeingEdited == EDIT_BT_AUTO_RECONNECT || settingBeingEdited == EDIT_SHOW_TOTAL_TIME) {
             StickCP2.Lcd.drawString(getUpButtonLabel() + " or " + getDownButtonLabel() + " = Toggle", StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() - 25);
         } else {
             StickCP2.Lcd.drawString(getUpButtonLabel() + "=Up / " + getDownButtonLabel() + "=Down", StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() - 25);
@@ -307,9 +317,10 @@ void displayEditScreen() {
         case EDIT_ROTATION:
         case EDIT_BT_VOLUME:
         case EDIT_BT_AUDIO_OFFSET: 
+        case EDIT_MIN_FIRST_SHOT:
              StickCP2.Lcd.setTextFont(7); StickCP2.Lcd.setTextSize(1);
              StickCP2.Lcd.drawNumber(editingIntValue, StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() / 2);
-             if (settingBeingEdited == EDIT_BT_AUDIO_OFFSET) { 
+             if (settingBeingEdited == EDIT_BT_AUDIO_OFFSET || settingBeingEdited == EDIT_MIN_FIRST_SHOT) { 
                 StickCP2.Lcd.setTextFont(0); StickCP2.Lcd.setTextSize(1); 
                 StickCP2.Lcd.drawString("ms", StickCP2.Lcd.width() / 2 + StickCP2.Lcd.textWidth(String(editingIntValue))/2 + 15, StickCP2.Lcd.height() / 2);
              }
@@ -326,6 +337,7 @@ void displayEditScreen() {
         case EDIT_BOOT_ANIM:
         case EDIT_AUTO_SLEEP:
         case EDIT_BT_AUTO_RECONNECT:
+        case EDIT_SHOW_TOTAL_TIME:
              StickCP2.Lcd.setTextFont(4); StickCP2.Lcd.setTextSize(1);
              StickCP2.Lcd.drawString(editingBoolValue ? "On" : "Off", StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() / 2);
              break;

--- a/code/display_utils.cpp
+++ b/code/display_utils.cpp
@@ -278,9 +278,53 @@ void displayStoppedScreen() {
         y_pos += line_h;
     }
 
+    StickCP2.Lcd.setTextDatum(BC_DATUM);
     StickCP2.Lcd.setTextSize(1);
-    StickCP2.Lcd.setCursor(30, StickCP2.Lcd.height() - 20);
-    StickCP2.Lcd.print("Press Front to Reset");
+    if (shotCount > 0) {
+        StickCP2.Lcd.drawString("Scroll=Shots / Front=Reset", StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() - 5);
+    } else {
+        StickCP2.Lcd.drawString("Press Front to Reset", StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() - 5);
+    }
+    drawLowBatteryIndicator();
+}
+
+void displayShotReviewScreen(int index) {
+    StickCP2.Lcd.fillScreen(BLACK);
+    StickCP2.Lcd.setTextFont(0);
+    StickCP2.Lcd.setTextColor(WHITE, BLACK);
+    int rotation = StickCP2.Lcd.getRotation();
+    int text_size = (rotation % 2 == 0) ? 1 : 2;
+    int line_h = (text_size == 1) ? 16 : 22;
+
+    // Title
+    StickCP2.Lcd.setTextDatum(TC_DATUM);
+    StickCP2.Lcd.setTextSize(text_size);
+    char title[20];
+    snprintf(title, sizeof(title), "Shot %d / %d", index + 1, shotCount);
+    StickCP2.Lcd.drawString(title, StickCP2.Lcd.width() / 2, 10);
+
+    // Shot time from buzzer
+    int y_pos = 10 + line_h + 8;
+    StickCP2.Lcd.setTextDatum(TL_DATUM);
+    StickCP2.Lcd.setTextSize(text_size);
+
+    float timeFromStart = (shotTimestamps[index] - startTime) / 1000.0f;
+    StickCP2.Lcd.setCursor(10, y_pos);
+    StickCP2.Lcd.printf("Time: %.2fs", timeFromStart);
+    y_pos += line_h;
+
+    // Split time
+    StickCP2.Lcd.setCursor(10, y_pos);
+    if (index == 0) {
+        StickCP2.Lcd.printf("Draw: %.2fs", splitTimes[0]);
+    } else {
+        StickCP2.Lcd.printf("Split: %.2fs", splitTimes[index]);
+    }
+
+    // Navigation hint
+    StickCP2.Lcd.setTextDatum(BC_DATUM);
+    StickCP2.Lcd.setTextSize(1);
+    StickCP2.Lcd.drawString("Scroll=Shots / Front=Reset", StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() - 5);
     drawLowBatteryIndicator();
 }
 

--- a/code/display_utils.h
+++ b/code/display_utils.h
@@ -8,6 +8,7 @@ void displayBootScreen(const char* line1a, const char* line1b, const char* line2
 void displayMenu(const char* title, const char* items[], int count, int selection, int scrollOffset);
 void displayTimingScreen(float elapsedTime, int count, float lastSplit);
 void displayStoppedScreen();
+void displayShotReviewScreen(int index);
 void displayEditScreen();
 void displayCalibrationScreen(const char* title, float peakValue, const char* unit);
 void displayDeviceStatusScreen();

--- a/code/globals.h
+++ b/code/globals.h
@@ -77,6 +77,7 @@ extern unsigned long lastDetectionTime;
 // Menu Variables
 extern int currentMenuSelection;
 extern int menuScrollOffset;
+extern int shotReviewIndex;
 extern int settingsMenuLevel;
 extern unsigned long btnTopPressTime;
 extern bool btnTopHeld;

--- a/code/globals.h
+++ b/code/globals.h
@@ -33,6 +33,8 @@ extern float recoilThreshold;
 extern int screenRotationSetting;
 extern bool playBootAnimation;
 extern bool enableAutoSleep;
+extern bool showTotalTime;
+extern int minFirstShotTimeMs;
 
 // --- Bluetooth Variables ---
 extern BluetoothA2DPSource a2dp_source;

--- a/code/globals.h
+++ b/code/globals.h
@@ -35,6 +35,7 @@ extern bool playBootAnimation;
 extern bool enableAutoSleep;
 extern bool showTotalTime;
 extern int minFirstShotTimeMs;
+extern int postBeepDelayMs;
 
 // --- Bluetooth Variables ---
 extern BluetoothA2DPSource a2dp_source;

--- a/code/input_handler.cpp
+++ b/code/input_handler.cpp
@@ -60,7 +60,7 @@ void handleSettingsInput() {
     int itemsPerScreen = (rotation % 2 == 0) ? MENU_ITEMS_PER_SCREEN_PORTRAIT : MENU_ITEMS_PER_SCREEN_LANDSCAPE;
 
     static const char* mainItems[] = {"General", "Bluetooth", "Dry Fire", "Noisy Range", "Device Status", "List Files", "Power Off Now", "Save & Exit"};
-    static const char* generalItems[] = {"Max Shots", "Beep Settings", "Shot Threshold", "Min 1st Shot", "Screen Rotation", "Boot Animation", "Auto Sleep", "Show Total Time", "Calibrate Thresh.", "Back"};
+    static const char* generalItems[] = {"Max Shots", "Beep Settings", "Shot Threshold", "Min 1st Shot", "Post Beep Delay", "Screen Rotation", "Boot Animation", "Auto Sleep", "Show Total Time", "Calibrate Thresh.", "Back"};
     static const char* beepItems[] = {"Beep Duration", "Beep Tone", "Back"};
     static const char* noisyItems[] = {"Recoil Threshold", "Calibrate Recoil", "Back"};
 
@@ -198,6 +198,8 @@ void handleSettingsInput() {
                 settingBeingEdited = EDIT_SHOT_THRESHOLD; editingIntValue = shotThresholdRms; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
             } else if (strcmp(editingSettingName, "Min 1st Shot") == 0) {
                 settingBeingEdited = EDIT_MIN_FIRST_SHOT; editingIntValue = minFirstShotTimeMs; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
+            } else if (strcmp(editingSettingName, "Post Beep Delay") == 0) {
+                settingBeingEdited = EDIT_POST_BEEP_DELAY; editingIntValue = postBeepDelayMs; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
             } else if (strcmp(editingSettingName, "Screen Rotation") == 0) {
                 settingBeingEdited = EDIT_ROTATION; editingIntValue = screenRotationSetting; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
             } else if (strcmp(editingSettingName, "Boot Animation") == 0) {
@@ -359,6 +361,7 @@ void handleEditSettingInput() {
             case EDIT_BEEP_TONE: editingIntValue = min(max(editingIntValue + (increment * 100), 500), 8000); break;
             case EDIT_SHOT_THRESHOLD: editingIntValue = min(max(editingIntValue + (increment * 500), 100), 32000); break;
             case EDIT_MIN_FIRST_SHOT: editingIntValue = min(max(editingIntValue + (increment * 10), 0), 500); break;
+            case EDIT_POST_BEEP_DELAY: editingIntValue = min(max(editingIntValue + (increment * 25), 50), 1000); break;
             case EDIT_PAR_BEEP_COUNT: editingIntValue = min(max(editingIntValue + increment, 1), MAX_PAR_BEEPS); break;
             case EDIT_PAR_TIME_ARRAY: editingFloatValue = min(max(editingFloatValue + (increment * 0.1f), 0.1f), 10.0f); break;
             case EDIT_RECOIL_THRESHOLD: editingFloatValue = min(max(editingFloatValue + (increment * 0.1f), 0.5f), 5.0f); break;
@@ -412,6 +415,7 @@ void handleEditSettingInput() {
             case EDIT_BEEP_TONE: currentBeepToneHz = editingIntValue; break;
             case EDIT_SHOT_THRESHOLD: shotThresholdRms = editingIntValue; break;
             case EDIT_MIN_FIRST_SHOT: minFirstShotTimeMs = editingIntValue; break;
+            case EDIT_POST_BEEP_DELAY: postBeepDelayMs = editingIntValue; break;
             case EDIT_PAR_BEEP_COUNT: dryFireParBeepCount = editingIntValue; break;
             case EDIT_PAR_TIME_ARRAY:
                 if (editingIntValue >= 0 && editingIntValue < MAX_PAR_BEEPS) { 

--- a/code/input_handler.cpp
+++ b/code/input_handler.cpp
@@ -60,7 +60,7 @@ void handleSettingsInput() {
     int itemsPerScreen = (rotation % 2 == 0) ? MENU_ITEMS_PER_SCREEN_PORTRAIT : MENU_ITEMS_PER_SCREEN_LANDSCAPE;
 
     static const char* mainItems[] = {"General", "Bluetooth", "Dry Fire", "Noisy Range", "Device Status", "List Files", "Power Off Now", "Save & Exit"};
-    static const char* generalItems[] = {"Max Shots", "Beep Settings", "Shot Threshold", "Screen Rotation", "Boot Animation", "Auto Sleep", "Calibrate Thresh.", "Back"};
+    static const char* generalItems[] = {"Max Shots", "Beep Settings", "Shot Threshold", "Min 1st Shot", "Screen Rotation", "Boot Animation", "Auto Sleep", "Show Total Time", "Calibrate Thresh.", "Back"};
     static const char* beepItems[] = {"Beep Duration", "Beep Tone", "Back"};
     static const char* noisyItems[] = {"Recoil Threshold", "Calibrate Recoil", "Back"};
 
@@ -196,12 +196,16 @@ void handleSettingsInput() {
                 settingsMenuLevel = 4; currentMenuSelection = 0; menuScrollOffset = 0; 
             } else if (strcmp(editingSettingName, "Shot Threshold") == 0) {
                 settingBeingEdited = EDIT_SHOT_THRESHOLD; editingIntValue = shotThresholdRms; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
+            } else if (strcmp(editingSettingName, "Min 1st Shot") == 0) {
+                settingBeingEdited = EDIT_MIN_FIRST_SHOT; editingIntValue = minFirstShotTimeMs; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
             } else if (strcmp(editingSettingName, "Screen Rotation") == 0) {
                 settingBeingEdited = EDIT_ROTATION; editingIntValue = screenRotationSetting; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
             } else if (strcmp(editingSettingName, "Boot Animation") == 0) {
                 settingBeingEdited = EDIT_BOOT_ANIM; editingBoolValue = playBootAnimation; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
             } else if (strcmp(editingSettingName, "Auto Sleep") == 0) {
                 settingBeingEdited = EDIT_AUTO_SLEEP; editingBoolValue = enableAutoSleep; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
+            } else if (strcmp(editingSettingName, "Show Total Time") == 0) {
+                settingBeingEdited = EDIT_SHOW_TOTAL_TIME; editingBoolValue = showTotalTime; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
             } else if (strcmp(editingSettingName, "Calibrate Thresh.") == 0) {
                 setState(CALIBRATE_THRESHOLD); peakRMSOverall = 0; micPeakRMS.resetPeak(); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
             } else if (strcmp(editingSettingName, "Back") == 0) {
@@ -354,12 +358,14 @@ void handleEditSettingInput() {
             case EDIT_BEEP_DURATION: editingULongValue = min(max(editingULongValue + (unsigned long)(increment * 50), 50UL), 2000UL); break;
             case EDIT_BEEP_TONE: editingIntValue = min(max(editingIntValue + (increment * 100), 500), 8000); break;
             case EDIT_SHOT_THRESHOLD: editingIntValue = min(max(editingIntValue + (increment * 500), 100), 32000); break;
+            case EDIT_MIN_FIRST_SHOT: editingIntValue = min(max(editingIntValue + (increment * 10), 0), 500); break;
             case EDIT_PAR_BEEP_COUNT: editingIntValue = min(max(editingIntValue + increment, 1), MAX_PAR_BEEPS); break;
             case EDIT_PAR_TIME_ARRAY: editingFloatValue = min(max(editingFloatValue + (increment * 0.1f), 0.1f), 10.0f); break;
             case EDIT_RECOIL_THRESHOLD: editingFloatValue = min(max(editingFloatValue + (increment * 0.1f), 0.5f), 5.0f); break;
             case EDIT_ROTATION: editingIntValue = (editingIntValue + increment + 4) % 4; break;
             case EDIT_BOOT_ANIM: editingBoolValue = !editingBoolValue; break;
             case EDIT_AUTO_SLEEP: editingBoolValue = !editingBoolValue; break;
+            case EDIT_SHOW_TOTAL_TIME: editingBoolValue = !editingBoolValue; break;
             case EDIT_BT_AUTO_RECONNECT: editingBoolValue = !editingBoolValue; break;
             case EDIT_BT_VOLUME:
                 editingIntValue = min(max(editingIntValue + (increment * 5), 0), 127);
@@ -381,6 +387,7 @@ void handleEditSettingInput() {
         if (valueChanged && 
             settingBeingEdited != EDIT_BOOT_ANIM && 
             settingBeingEdited != EDIT_AUTO_SLEEP && 
+            settingBeingEdited != EDIT_SHOW_TOTAL_TIME &&
             settingBeingEdited != EDIT_BT_AUTO_RECONNECT &&
             settingBeingEdited != EDIT_BT_AUDIO_OFFSET) { 
             playFeedbackTone(2500, 20); 
@@ -404,6 +411,7 @@ void handleEditSettingInput() {
             case EDIT_BEEP_DURATION: currentBeepDuration = editingULongValue; break;
             case EDIT_BEEP_TONE: currentBeepToneHz = editingIntValue; break;
             case EDIT_SHOT_THRESHOLD: shotThresholdRms = editingIntValue; break;
+            case EDIT_MIN_FIRST_SHOT: minFirstShotTimeMs = editingIntValue; break;
             case EDIT_PAR_BEEP_COUNT: dryFireParBeepCount = editingIntValue; break;
             case EDIT_PAR_TIME_ARRAY:
                 if (editingIntValue >= 0 && editingIntValue < MAX_PAR_BEEPS) { 
@@ -414,6 +422,7 @@ void handleEditSettingInput() {
             case EDIT_ROTATION: screenRotationSetting = editingIntValue; break;
             case EDIT_BOOT_ANIM: playBootAnimation = editingBoolValue; break;
             case EDIT_AUTO_SLEEP: enableAutoSleep = editingBoolValue; break;
+            case EDIT_SHOW_TOTAL_TIME: showTotalTime = editingBoolValue; break;
             case EDIT_BT_AUTO_RECONNECT:
                 currentBluetoothAutoReconnect = editingBoolValue;
                 break;

--- a/code/input_handler.cpp
+++ b/code/input_handler.cpp
@@ -61,7 +61,7 @@ void handleSettingsInput() {
 
     static const char* mainItems[] = {"General", "Bluetooth", "Dry Fire", "Noisy Range", "Device Status", "List Files", "Power Off Now", "Save & Exit"};
     static const char* generalItems[] = {"Max Shots", "Beep Settings", "Shot Threshold", "Min 1st Shot", "Post Beep Delay", "Screen Rotation", "Boot Animation", "Auto Sleep", "Show Total Time", "Calibrate Thresh.", "Back"};
-    static const char* beepItems[] = {"Beep Duration", "Beep Tone", "Back"};
+    static const char* beepItems[] = {"Beep Duration", "Beep Tone", "Tone Sweep", "Back"};
     static const char* noisyItems[] = {"Recoil Threshold", "Calibrate Recoil", "Back"};
 
     const int maxDryFireItems = 1 + MAX_PAR_BEEPS + 1;
@@ -256,6 +256,8 @@ void handleSettingsInput() {
                 settingBeingEdited = EDIT_BEEP_DURATION; editingULongValue = currentBeepDuration; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
             } else if (strcmp(editingSettingName, "Beep Tone") == 0) {
                 settingBeingEdited = EDIT_BEEP_TONE; editingIntValue = currentBeepToneHz; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
+            } else if (strcmp(editingSettingName, "Tone Sweep") == 0) {
+                settingBeingEdited = EDIT_TONE_SWEEP; editingIntValue = 2000; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
             } else if (strcmp(editingSettingName, "Back") == 0) {
                 settingsMenuLevel = 1; currentMenuSelection = 1; 
                 menuScrollOffset = 0;
@@ -381,6 +383,10 @@ void handleEditSettingInput() {
                     playFeedbackTone(2500, 20); 
                 }
                 break;
+            case EDIT_TONE_SWEEP:
+                editingIntValue = min(max(editingIntValue + (increment * 50), 2000), 4000);
+                playFeedbackTone(editingIntValue, 100);
+                break;
             default: valueChanged = false; break;
         }
         if (settingBeingEdited == EDIT_ROTATION) {
@@ -392,7 +398,8 @@ void handleEditSettingInput() {
             settingBeingEdited != EDIT_AUTO_SLEEP && 
             settingBeingEdited != EDIT_SHOW_TOTAL_TIME &&
             settingBeingEdited != EDIT_BT_AUTO_RECONNECT &&
-            settingBeingEdited != EDIT_BT_AUDIO_OFFSET) { 
+            settingBeingEdited != EDIT_BT_AUDIO_OFFSET &&
+            settingBeingEdited != EDIT_TONE_SWEEP) { 
             playFeedbackTone(2500, 20); 
         }
     }
@@ -413,6 +420,7 @@ void handleEditSettingInput() {
             case EDIT_MAX_SHOTS: currentMaxShots = editingIntValue; break;
             case EDIT_BEEP_DURATION: currentBeepDuration = editingULongValue; break;
             case EDIT_BEEP_TONE: currentBeepToneHz = editingIntValue; break;
+            case EDIT_TONE_SWEEP: currentBeepToneHz = editingIntValue; break;
             case EDIT_SHOT_THRESHOLD: shotThresholdRms = editingIntValue; break;
             case EDIT_MIN_FIRST_SHOT: minFirstShotTimeMs = editingIntValue; break;
             case EDIT_POST_BEEP_DELAY: postBeepDelayMs = editingIntValue; break;

--- a/code/nvs_utils.cpp
+++ b/code/nvs_utils.cpp
@@ -27,6 +27,10 @@ void loadSettings() {
     if (screenRotationSetting < 0 || screenRotationSetting > 3) screenRotationSetting = 3;
     playBootAnimation = preferences.getBool(KEY_BOOT_ANIM, true);
     enableAutoSleep = preferences.getBool(KEY_AUTO_SLEEP, true);
+    showTotalTime = preferences.getBool(KEY_SHOW_TOTAL_TIME, false);
+    minFirstShotTimeMs = preferences.getInt(KEY_MIN_FIRST_SHOT, DEFAULT_MIN_FIRST_SHOT_TIME_MS);
+    if (minFirstShotTimeMs < 0) minFirstShotTimeMs = 0;
+    if (minFirstShotTimeMs > 500) minFirstShotTimeMs = 500;
 
     currentBluetoothDeviceName = preferences.getString(KEY_BT_DEVICE_NAME, "LEXON MINO L");
     currentBluetoothAutoReconnect = preferences.getBool(KEY_BT_AUTO_RECONNECT, false);
@@ -54,6 +58,8 @@ void saveSettings() {
     preferences.putInt(KEY_ROTATION, screenRotationSetting);
     preferences.putBool(KEY_BOOT_ANIM, playBootAnimation);
     preferences.putBool(KEY_AUTO_SLEEP, enableAutoSleep);
+    preferences.putBool(KEY_SHOW_TOTAL_TIME, showTotalTime);
+    preferences.putInt(KEY_MIN_FIRST_SHOT, minFirstShotTimeMs);
 
     preferences.putString(KEY_BT_DEVICE_NAME, currentBluetoothDeviceName);
     preferences.putBool(KEY_BT_AUTO_RECONNECT, currentBluetoothAutoReconnect);

--- a/code/nvs_utils.cpp
+++ b/code/nvs_utils.cpp
@@ -31,6 +31,9 @@ void loadSettings() {
     minFirstShotTimeMs = preferences.getInt(KEY_MIN_FIRST_SHOT, DEFAULT_MIN_FIRST_SHOT_TIME_MS);
     if (minFirstShotTimeMs < 0) minFirstShotTimeMs = 0;
     if (minFirstShotTimeMs > 500) minFirstShotTimeMs = 500;
+    postBeepDelayMs = preferences.getInt(KEY_POST_BEEP_DELAY, DEFAULT_POST_BEEP_DELAY_MS);
+    if (postBeepDelayMs < 50) postBeepDelayMs = 50;
+    if (postBeepDelayMs > 1000) postBeepDelayMs = 1000;
 
     currentBluetoothDeviceName = preferences.getString(KEY_BT_DEVICE_NAME, "LEXON MINO L");
     currentBluetoothAutoReconnect = preferences.getBool(KEY_BT_AUTO_RECONNECT, false);
@@ -60,6 +63,7 @@ void saveSettings() {
     preferences.putBool(KEY_AUTO_SLEEP, enableAutoSleep);
     preferences.putBool(KEY_SHOW_TOTAL_TIME, showTotalTime);
     preferences.putInt(KEY_MIN_FIRST_SHOT, minFirstShotTimeMs);
+    preferences.putInt(KEY_POST_BEEP_DELAY, postBeepDelayMs);
 
     preferences.putString(KEY_BT_DEVICE_NAME, currentBluetoothDeviceName);
     preferences.putBool(KEY_BT_AUTO_RECONNECT, currentBluetoothAutoReconnect);

--- a/code/system_utils.cpp
+++ b/code/system_utils.cpp
@@ -9,6 +9,9 @@ void setState(TimerState newState) {
         previousState = currentState;
         currentState = newState;
         redrawMenu = true;
+        if (newState == LIVE_FIRE_STOPPED) {
+            shotReviewIndex = -1;
+        }
     }
 }
 

--- a/code/timer_modes.cpp
+++ b/code/timer_modes.cpp
@@ -57,9 +57,9 @@ void handleLiveFireGetReady() {
     is_listening_active = false; // Don't listen until beep is finished
 
     // Set timer start time relative to beep initiation + standard delay
-    startTime = beepInitiationTime + POST_BEEP_DELAY_MS; 
+    startTime = beepInitiationTime + postBeepDelayMs; 
     
-    delay(POST_BEEP_DELAY_MS); // Wait for the standard post-beep delay
+    delay(postBeepDelayMs); // Wait for the standard post-beep delay
     
     resetShotData(); 
     lastDisplayUpdateTime = 0;
@@ -75,7 +75,7 @@ void handleLiveFireTiming() {
     // --- Check if listening should become active ---
     if (!is_listening_active) {
         // Check if enough time has passed since the calculated end of beep audio
-        // AND ensure the timer has actually started (passed POST_BEEP_DELAY_MS)
+        // AND ensure the timer has actually started (passed postBeepDelayMs)
         if (currentTime >= beep_audio_end_time && currentTime >= startTime) { 
             is_listening_active = true;
             micPeakRMS.resetPeak(); // Reset peak *just* as listening starts
@@ -320,9 +320,9 @@ void handleNoisyRangeGetReady() {
     beep_audio_end_time = max(beepInitiationTime, audioStartTime) + audioDuration + 150; // Increased buffer
     is_listening_active = false; 
 
-    startTime = beepInitiationTime + POST_BEEP_DELAY_MS; 
+    startTime = beepInitiationTime + postBeepDelayMs; 
 
-    delay(POST_BEEP_DELAY_MS); 
+    delay(postBeepDelayMs); 
     
     resetShotData();
     lastDisplayUpdateTime = 0;

--- a/code/timer_modes.cpp
+++ b/code/timer_modes.cpp
@@ -113,7 +113,8 @@ void handleLiveFireTiming() {
     if (currentCyclePeakRMS > shotThresholdRms && 
         currentTime - lastDetectionTime > SHOT_REFRACTORY_MS && 
         shotCount < currentMaxShots && 
-        startTime > 0) 
+        startTime > 0 &&
+        (shotCount > 0 || (currentTime - startTime) >= minFirstShotTimeMs)) 
     {
         unsigned long shotTimeMillis = currentTime; 
         resetActivityTimer();
@@ -370,7 +371,8 @@ void handleNoisyRangeTiming() {
         currentCyclePeakRMS > shotThresholdRms &&
         currentTime - lastDetectionTime > SHOT_REFRACTORY_MS &&
         shotCount < currentMaxShots &&
-        startTime > 0) 
+        startTime > 0 &&
+        (shotCount > 0 || (currentTime - startTime) >= minFirstShotTimeMs)) 
     {
         lastSoundPeakTime = currentTime;
         checkingForRecoil = true;


### PR DESCRIPTION
Added total time from buzzer to last recorded shot display and added a toggle for it in settings under General.

I noticed that MIN_FIRST_SHOT_TIME_MS was referenced in config but no where else. I made it work and added it to be a settings menu setting for adjustment at the range.

Noticed the internal and external buzzers were being called sequentially leading to a "lag" in the sound as the external fired after the internal. Combined them.

Added a menu item to tweak the time between buzzer and timer start.

Added beep sweep option in the beep settings to scroll through frequencies to find the best for your external buzzer

Added the ability to scroll through each shot at the summary screen

Feel free to take all, any or none of this. These are just QOL improvements for my usecase and figured someone else may like them.